### PR TITLE
Fix SignInPage map closure and invalid style

### DIFF
--- a/source/Pages/SignInPage.tsx
+++ b/source/Pages/SignInPage.tsx
@@ -135,7 +135,7 @@ const SignInPage: React.FC = () => {
                                 onChange={data => updateEnteredDetails(id, data.nativeEvent.text, index + 1)}
                             />
                         );
-                    })}
+                    })
                 </View>
                 {error.pin && <Text style={styles.errorText}>Enter 4 digit Pin </Text>}
                 <View style={{ height: 10 }} />
@@ -208,7 +208,7 @@ const styles = StyleSheet.create({
         marginTop: '5%',
         marginBottom: '3%',
         color: "#FFFFFF",
-        fontWeight: 'heavy',
+        fontWeight: 'bold',
         fontSize: 20,
         textAlign: 'center'
     },


### PR DESCRIPTION
## Summary
- correct map closure in pin input view
- use a valid `fontWeight` value for the pin label style

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbab2b738832389790ca835efadbe