### PR TITLE
Integrate Redux with persistence

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -13,8 +13,11 @@ import {it} from '@jest/globals';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
-it('renders correctly', async () => {
-  await ReactTestRenderer.act(() => {
+it('renders correctly', () => {
+  jest.useFakeTimers();
+  ReactTestRenderer.act(() => {
     ReactTestRenderer.create(<App />);
   });
+  jest.runAllTimers();
+  jest.useRealTimers();
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
 module.exports = {
   preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-navigation|react-redux|redux-persist|react-native-linear-gradient|@react-native-async-storage)/)',
+  ],
+  setupFiles: ['./jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+jest.mock('react-native-linear-gradient', () => 'LinearGradient');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobileapp",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-clipboard/clipboard": "^1.16.2",
         "@react-navigation/native": "^6.1.18",
         "@react-navigation/native-stack": "^6.11.0",
@@ -18,6 +19,9 @@
         "react-native-paper": "^5.12.5",
         "react-native-safe-area-context": "^5.4.1",
         "react-native-screens": "^4.11.1",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1",
+        "redux-persist": "^6.0.0",
         "rn-secure-storage": "^3.0.1"
       },
       "devDependencies": {
@@ -2512,6 +2516,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-clipboard/clipboard": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.16.2.tgz",
@@ -3518,6 +3534,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -7176,6 +7198,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -8423,6 +8454,18 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9805,6 +9848,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -9844,6 +9910,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": ">4.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11063,6 +11144,15 @@
       "integrity": "sha512-8nhb73STSD/z3GTHklvNjL8F9wMOo0bj0AFnulpIYuFTm6aQlT3ZcNbXF2YurKImIY8+kpSFSDHZZyQmurGrhw==",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.2",
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.11.0",
@@ -20,6 +21,9 @@
     "react-native-paper": "^5.12.5",
     "react-native-safe-area-context": "^5.4.1",
     "react-native-screens": "^4.11.1",
+    "react-redux": "^9.2.0",
+    "redux": "^5.0.1",
+    "redux-persist": "^6.0.0",
     "rn-secure-storage": "^3.0.1"
   },
   "devDependencies": {

--- a/source/Pages/HomePage.tsx
+++ b/source/Pages/HomePage.tsx
@@ -1,12 +1,31 @@
 import React from "react";
 import { Text, View } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
+import { setLoginStatus } from "../redux/loginReducer";
+import { RootState } from "../redux/store";
+import Button from "../Components/UI/Button";
+import { useNavigation } from "@react-navigation/native";
+import { MainNavigationProp } from "../Navigation/MainNav";
 
 const HomePage: React.FC = () => {
+    const dispatch = useDispatch();
+    const navigation = useNavigation<MainNavigationProp>();
+    const userName = useSelector((state: RootState) => state.login.loginDetails.userName);
+
+    const logout = () => {
+        dispatch(setLoginStatus(false, {}));
+        navigation.replace('SignIn');
+    };
+
     return (
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
             <Text style={{ fontSize: 30, color: 'red' }}>Home Page</Text>
+            {userName && (
+                <Text style={{ fontSize: 20, marginVertical: 10 }}>Welcome, {userName}</Text>
+            )}
+            <Button label="Logout" color="#144bb8" textColor="#fff" onPress={logout} />
         </View>
-    )
-}
+    );
+};
 
 export default HomePage

--- a/source/Pages/SignInPage.tsx
+++ b/source/Pages/SignInPage.tsx
@@ -1,11 +1,12 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Image, StyleSheet, Text, View, TextInput as ReactTextInput, Keyboard } from "react-native";
 import { _GLOBAL_COLORS } from "../Util/ColorConstants";
 import LinearGradient from "react-native-linear-gradient";
-import { GlobalContext } from "../../App";
+import { useSelector, useDispatch } from "react-redux";
+import { RootState } from "../redux/store";
+import { setLoginStatus } from "../redux/loginReducer";
 import { TextInput } from "react-native-paper";
 import Button from "../Components/UI/Button";
-import RNSecureStorage, { ACCESSIBLE } from "rn-secure-storage";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { MainNavigationProp } from "../Navigation/MainNav";
 
@@ -17,12 +18,8 @@ interface LoginDetails {
     pin_4: string;
 }
 
-interface GlobalContextType {
-    isLogin: boolean;
-    loginDetails: LoginDetails;
-}
-
 const SignInPage: React.FC = () => {
+    const dispatch = useDispatch();
     const {
         isLogin,
         loginDetails: {
@@ -32,7 +29,7 @@ const SignInPage: React.FC = () => {
             pin_3 = '',
             pin_4 = ''
         } = {} as LoginDetails
-    } = useContext(GlobalContext) as unknown as GlobalContextType;
+    } = useSelector((state: RootState) => state.login);
 
 
     type EnteredDetails = {
@@ -60,8 +57,10 @@ const SignInPage: React.FC = () => {
     const fourthPinRef = useRef<ReactTextInput>(null);
 
     useEffect(() => {
-
-    }, [isLogin]);
+        if (isLogin) {
+            navigation.replace('Home');
+        }
+    }, [isLogin, navigation]);
 
     const updateEnteredDetails = (identifier: keyof EnteredDetails, value: string, index?: number) => {
         if (value.length <= 1) {
@@ -159,12 +158,8 @@ const SignInPage: React.FC = () => {
         if (Object.values(errors).some(flag => flag)) {
             setError({ userName: errors.userName, pin: errors.pin });
         } else {
-            RNSecureStorage.setItem("UserInfo", JSON.stringify(enteredDetails), { accessible: ACCESSIBLE.WHEN_UNLOCKED }).then((res) => {
-                console.log(res);
-                navigation.navigate('Home');
-            }).catch((err) => {
-                console.log(err);
-            });
+            dispatch(setLoginStatus(true, enteredDetails));
+            navigation.navigate('Home');
         }
     }
 

--- a/source/redux/loginReducer.ts
+++ b/source/redux/loginReducer.ts
@@ -1,0 +1,50 @@
+export interface LoginDetails {
+  userName?: string;
+  pin_1?: string;
+  pin_2?: string;
+  pin_3?: string;
+  pin_4?: string;
+}
+
+export interface LoginState {
+  isLogin: boolean;
+  loginDetails: LoginDetails;
+}
+
+const SET_LOGIN_STATUS = 'SET_LOGIN_STATUS';
+
+interface SetLoginStatusAction {
+  type: typeof SET_LOGIN_STATUS;
+  payload: { flag: boolean; details: LoginDetails };
+}
+
+export type LoginActionTypes = SetLoginStatusAction;
+
+export const setLoginStatus = (
+  flag: boolean,
+  details: LoginDetails,
+): SetLoginStatusAction => ({
+  type: SET_LOGIN_STATUS,
+  payload: { flag, details },
+});
+
+const initialState: LoginState = {
+  isLogin: false,
+  loginDetails: {},
+};
+
+export const loginReducer = (
+  state = initialState,
+  action: LoginActionTypes,
+): LoginState => {
+  switch (action.type) {
+    case SET_LOGIN_STATUS:
+      return {
+        ...state,
+        isLogin: action.payload.flag,
+        loginDetails: action.payload.details,
+      };
+    default:
+      return state;
+  }
+};

--- a/source/redux/store.ts
+++ b/source/redux/store.ts
@@ -1,0 +1,20 @@
+import { legacy_createStore as createStore, combineReducers } from 'redux';
+import { persistStore, persistReducer } from 'redux-persist';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { loginReducer } from './loginReducer';
+
+const rootReducer = combineReducers({
+  login: loginReducer,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+const persistConfig = {
+  key: 'root',
+  storage: AsyncStorage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+export const store = createStore(persistedReducer);
+export const persistor = persistStore(store);


### PR DESCRIPTION
## Summary
- add redux-persist setup and hooks
- add logout button in HomePage
- mock native modules for tests
- adjust Jest config for React Native modules
- ensure tests use fake timers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dbe27313c8323a27c863d68fe1d3b